### PR TITLE
radio-iris: Fix broken hci_smd init

### DIFF
--- a/include/media/radio-iris.h
+++ b/include/media/radio-iris.h
@@ -175,7 +175,6 @@ struct radio_hci_dev {
 	int (*send)(struct sk_buff *skb);
 	void (*destruct)(struct radio_hci_dev *hdev);
 	void (*notify)(struct radio_hci_dev *hdev, unsigned int evt);
-	void (*close_smd)(void);
 };
 
 int radio_hci_register_dev(struct radio_hci_dev *hdev);


### PR DESCRIPTION
 * Change back to the good old and working modular driver.
   This reverts commit 011e2beb52577abe7e648e6361e182d27f6644f8 and partially reverts commit ae657e649437e49e15e71f5d3855eb7c8451350c,
   while taking into account commit 1053aaee5ed845002ac43f182f20855234ed4ea3.

Change-Id: I0d0011481818fea94a878fbaa9b5a6d6562a363e